### PR TITLE
Update simpleTest.java

### DIFF
--- a/src/test/java/SimpleQueryTests/simpleTest.java
+++ b/src/test/java/SimpleQueryTests/simpleTest.java
@@ -44,8 +44,8 @@ public class simpleTest {
         System.out.println(RelOptUtil.toString(logicPlan));
         System.out.println(RelOptUtil.toString(logicPlan2));
         Context z3Context = new Context();
-        AlgeRule.normalize(AlgeNodeParserPair.constructAlgeNode(logicPlan, z3Context));
-        AlgeRule.normalize(AlgeNodeParserPair.constructAlgeNode(logicPlan2, z3Context));
+        algeExpr = AlgeRule.normalize(AlgeNodeParserPair.constructAlgeNode(logicPlan, z3Context));
+        algeExpr2 = AlgeRule.normalize(AlgeNodeParserPair.constructAlgeNode(logicPlan2, z3Context));
       }catch (Exception e){
         result.addProperty("decision","unknown");
         result.addProperty("reason","sql feature not support");


### PR DESCRIPTION
I modified lines 47 and 48 to update the values of algeExpr and algeExpr2. Without this modification, the values of algeExpr and algeExpr2 remain set to null, which leads to a null pointer exception being thrown at line 55. I tested simpleTest.java on my local machine and it runs with no problems after the modification.